### PR TITLE
fixes: using target="_black" without rel="noreferrer" is a security risk in older browsers. 

### DIFF
--- a/search-bar-code/src/Components/SearchBar.js
+++ b/search-bar-code/src/Components/SearchBar.js
@@ -47,7 +47,7 @@ function SearchBar({ placeholder, data }) {
         <div className="dataResult">
           {filteredData.slice(0, 15).map((value, key) => {
             return (
-              <a className="dataItem" href={value.link} target="_blank">
+              <a className="dataItem" href={value.link} target="_blank" rel="noreferrer">
                 <p>{value.title} </p>
               </a>
             );


### PR DESCRIPTION
Although it's a security risk all current versions of major browsers as of 2022 automatically use the behavior of rel="noreferrer" for any target="_blank" link, So the issue is taken care of.